### PR TITLE
Добавил UGCFileProvider

### DIFF
--- a/ugc/build.gradle
+++ b/ugc/build.gradle
@@ -8,8 +8,8 @@ android {
     defaultConfig {
         minSdk 21
         targetSdk 35
-        versionCode 122
-        versionName "1.2.5"
+        versionCode 123
+        versionName "1.2.6"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/ugc/src/main/AndroidManifest.xml
+++ b/ugc/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:supportsRtl="true">
 
         <provider
-            android:name="androidx.core.content.FileProvider"
+            android:name=".UGCFileProvider"
             android:authorities="${applicationId}.inappstory.sdk.ugc.fileProvider"
             android:exported="false"
             android:grantUriPermissions="true">

--- a/ugc/src/main/java/com/inappstory/sdk/ugc/UGCFileProvider.kt
+++ b/ugc/src/main/java/com/inappstory/sdk/ugc/UGCFileProvider.kt
@@ -1,0 +1,5 @@
+package com.inappstory.sdk.ugc
+
+import androidx.core.content.FileProvider
+
+class UGCFileProvider : FileProvider()


### PR DESCRIPTION
У нас во время мёрджа манифеста возникла ошибка:

```
Error:
        Attribute provider#androidx.core.content.FileProvider@authorities value=(#####) from AndroidManifest.xml:39:13-59
        is also present at [com.github.inappstory:ugc-android-sdk:1.2.5] AndroidManifest.xml:21:13-83 value=(#####.inappstory.sdk.ugc.fileProvider).
```

Чтобы этого избежать и не конфликтовать с другими библиотеками лучше завести для InAppStory UGC библиотеки свой `class UGCFileProvider : FileProvider()`. Логика не меняется, но так библиотеку будет проще подключать в приложение.